### PR TITLE
Bump Consul to version 1.6.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.6.1_linux_amd64.zip:
-  size: 39965581
-  object_id: 15da1b6b-d463-4b64-65ac-658de9d4bafd
-  sha: sha256:a8568ca7b6797030b2c32615b4786d4cc75ce7aee2ed9025996fe92b07b31f7e
+consul/consul_1.6.2_linux_amd64.zip:
+  size: 40138455
+  sha: sha256:78d127e5b8edd310c3f9f89487fb833a5c7bcb4e09cb731a4d39100fc53b38be

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.6.2_linux_amd64.zip:
   size: 40138455
+  object_id: 246ed553-cf34-46a9-7f81-bcdbd1071ebc
   sha: sha256:78d127e5b8edd310c3f9f89487fb833a5c7bcb4e09cb731a4d39100fc53b38be


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.6.2 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best