### PR TITLE
Bump Consul to version 1.6.2

### DIFF
--- a/ci/config.yml
+++ b/ci/config.yml
@@ -3,4 +3,4 @@ github_username: gk-concourse-ninja
 
 git_user_name: Gstack Concourse Ninja
 
-traefik_release_git_uri: git@github.com:gstackio/gk-consul-boshrelease.git
+consul_release_git_uri: git@github.com:gstackio/gk-consul-boshrelease.git

--- a/ci/consul-bump/consul-bump-pipeline.yml
+++ b/ci/consul-bump/consul-bump-pipeline.yml
@@ -1,0 +1,266 @@
+---
+
+resource_types:
+  - name: keyval
+    type: docker-image
+    source:
+      repository: swce/keyval-resource
+
+  - name: hashicorp-release
+    type: docker-image
+    source:
+      repository: starkandwayne/hashicorp-release-resource
+
+resources:
+  - name: kinja-image
+    type: docker-image
+    source:
+      repository: kinja/pipeline-image
+
+  - name: consul-zip-release
+    type: hashicorp-release
+    source:
+      project: consul
+
+  - name: consul-boshrelease-master
+    type: git
+    source:
+      uri: ((consul_release_git_uri))
+      branch: master
+      private_key: ((github_private_key))
+
+  - name: bump-info
+    type: keyval
+
+jobs:
+  - name: detect
+    plan:
+      - in_parallel:
+          - get: consul-zip-release
+            trigger: true
+            params: { regexp: linux_amd64.zip }
+          - get: consul-boshrelease-master
+          - get: kinja-image
+
+      - task: add-blob
+        input_mapping:
+          consul-boshrelease: consul-boshrelease-master
+        image: kinja-image
+        config:
+          platform: linux
+          inputs:
+            - name: consul-zip-release
+            - name: consul-boshrelease
+          outputs:
+            - name: consul-boshrelease-bumped
+            - name: bump-info
+          run:
+            path: /bin/bash
+            args:
+              - -exc
+              - |
+                find consul-zip-release -ls
+
+                echo version: $(< consul-zip-release/version)
+                echo project: $(< consul-zip-release/project)
+
+                latest_consul_version=$(< consul-zip-release/version)
+
+                git clone "consul-boshrelease" "consul-boshrelease-bumped"
+                branch_name="bump-consul-${latest_consul_version}"
+
+                pushd "consul-boshrelease-bumped" > /dev/null
+                    git checkout "master"
+                    git pull
+
+                    git checkout -b "${branch_name}"
+
+                    bosh blobs
+
+                    old_consul_sha256=$(
+                        bosh blobs --column path --column digest \
+                        | awk '/consul\/consul_[0-9.]+_linux_amd64\.zip/{sub("^sha256:", "", $2); print $2}')
+                    new_consul_sha256=$(
+                        shasum -a 256 "../consul-zip-release/consul_${latest_consul_version}_linux_amd64.zip" \
+                        | awk '{print $1}')
+                    if [[ ${new_consul_sha256} == ${old_consul_sha256} ]]; then
+                        echo "INFO: new blob has the same sha256 hash as the old one. Skipping blob update."
+                    else
+                        consul_old_blob_path=$(bosh blobs | awk '/consul\/consul_[0-9.]+_linux_amd64\.zip/{print $1}')
+
+                        bosh remove-blob "${consul_old_blob_path}"
+                        bosh add-blob "../consul-zip-release/consul_${latest_consul_version}_linux_amd64.zip" "consul/consul_${latest_consul_version}_linux_amd64.zip"
+
+                        bosh blobs
+                    fi
+
+                    echo "Updating 'packages/consul/packaging' file."
+                    sed -i -re "/CONSUL_VERSION=/s/=[0-9.]+\$/=${latest_consul_version}/" "packages/consul/packaging"
+                    grep -F -nC 2 "CONSUL_VERSION=" "packages/consul/packaging"
+
+                    echo "Updating 'scripts/add-blobs.sh' utility."
+                    consul_sha256=$(bosh blobs --column path --column digest | awk '/consul\/consul_[0-9.]+_linux_amd64\.zip/{sub("^sha256:", "", $2); print $2}')
+                    sed -i -re "/CONSUL_VERSION=/s/=[0-9.]+\$/=${latest_consul_version}/" "scripts/add-blobs.sh"
+                    sed -i -re "/CONSUL_SHA256=/s/=[0-9a-f]+\$/=${consul_sha256}/" "scripts/add-blobs.sh"
+                    grep -E -nC 2 "CONSUL_(VERSION|SHA256)=" "scripts/add-blobs.sh"
+
+                    git config --global "color.ui" "always"
+                    git status
+                    git diff | cat
+
+                    git config --global "user.name" "((git_user_name))"
+                    git config --global "user.email" "((git_user_email))"
+
+                    git add .
+                    git commit -m "Bump consul binary to version ${latest_consul_version}"
+                popd > /dev/null
+
+
+                # Write properties to the keyval output resource
+
+                mkdir -p bump-info
+                echo "latest_consul_version=${latest_consul_version}" >> bump-info/keyval.properties
+                echo "branch_name=${branch_name}"                     >> bump-info/keyval.properties
+
+      - put: bump-info
+        params:
+          file: bump-info/keyval.properties
+
+      - task: upload-blobs
+        params:
+          S3_ACCESS_KEY_ID: ((s3_access_key_id))
+          S3_SECRET_ACCESS_KEY: ((s3_secret_access_key))
+        image: kinja-image
+        config:
+          platform: linux
+          inputs:
+            - name: consul-boshrelease-bumped
+          outputs:
+            - name: consul-boshrelease-blobs-uploaded
+          params:
+            S3_ACCESS_KEY_ID:
+            S3_SECRET_ACCESS_KEY:
+          run:
+            path: /bin/bash
+            args:
+              - -exc
+              - |
+                git clone "consul-boshrelease-bumped" "consul-boshrelease-blobs-uploaded"
+                cp -Rp "consul-boshrelease-bumped/blobs" "consul-boshrelease-blobs-uploaded"
+
+                set +x
+                cat <<EOF > "consul-boshrelease-blobs-uploaded/config/private.yml"
+                ---
+                blobstore:
+                  options:
+                    access_key_id: ${S3_ACCESS_KEY_ID}
+                    secret_access_key: ${S3_SECRET_ACCESS_KEY}
+                EOF
+                set -x
+
+                pushd "consul-boshrelease-blobs-uploaded" > /dev/null
+                    bosh upload-blobs
+
+                    git config --global "user.name" "((git_user_name))"
+                    git config --global "user.email" "((git_user_email))"
+
+                    git add "config/blobs.yml"
+                    git commit -m "Uploaded blob for new Consul binary"
+                popd > /dev/null
+
+      - task: git-push
+        input_mapping:
+          repo: consul-boshrelease-blobs-uploaded
+        params:
+          GIT_URI: ((consul_release_git_uri))
+          GITHUB_PRIVATE_KEY: ((github_private_key))
+        image: kinja-image
+        config:
+          platform: linux
+          inputs:
+            - name: bump-info
+            - name: repo
+          params:
+            GIT_URI:
+            GITHUB_PRIVATE_KEY:
+          run:
+            path: /bin/bash
+            args:
+              - -exc
+              - |
+                mkdir -p "${HOME}/.ssh"
+                chmod 700 "${HOME}/.ssh"
+
+                touch "${HOME}/.ssh/id_rsa"
+                chmod 600 "${HOME}/.ssh/id_rsa"
+                cat <<< "${GITHUB_PRIVATE_KEY}" > "${HOME}/.ssh/id_rsa"
+
+                grep -vE "^(UPDATED|UUID)=" "bump-info/keyval.properties" \
+                    | sed -r -e 's/"/\"/g; s/=(.*)$/="\1"/' \
+                    > keyval.inc.bash
+                source "keyval.inc.bash"
+
+                pushd "repo" > /dev/null
+                    git remote set-url origin "${GIT_URI}"
+                    ssh-keyscan -t rsa "github.com" 2> /dev/null >> "${HOME}/.ssh/known_hosts"
+                    git push --set-upstream origin "${branch_name}"
+                popd > /dev/null
+
+      - task: submit-pr
+        params:
+          GH_ACCESS_TOKEN: ((github_access_token))
+          GH_OWNER: gstackio
+          GH_REPO: gk-consul-boshrelease
+        image: kinja-image
+        config:
+          platform: linux
+          inputs:
+            - name: bump-info
+          params:
+            GH_ACCESS_TOKEN:
+            GH_OWNER:
+            GH_REPO:
+          run:
+            path: /bin/bash
+            args:
+              - -exc
+              - |
+                grep -vE "^(UPDATED|UUID)=" "bump-info/keyval.properties" \
+                    | sed -r -e 's/"/\"/g; s/=(.*)$/="\1"/' \
+                    > keyval.inc.bash
+                source "keyval.inc.bash"
+
+                pr_desc="Hi there!"
+                pr_desc+="\\n"
+                pr_desc+="\\nI noticed that the new Consul v${latest_consul_version} is out,"
+                pr_desc+=" so I suggest we update this BOSH Release with the latest binary available."
+                pr_desc+="\\n"
+                pr_desc+="\\nHere in this PR, I've pulled that new binary in."
+                pr_desc+=" I uploaded the blob to the release blobstore, and here is the result."
+                pr_desc+="\\n"
+                pr_desc+="\\nLet's give it a shot, shall we?"
+                pr_desc+="\\n"
+                pr_desc+="\\nBest"
+
+                # See also: https://developer.github.com/v3/pulls/#create-a-pull-request
+                pr_data=$(jq -n \
+                    --arg title "Bump Consul to version ${latest_consul_version}" \
+                    --arg body "$(echo -e "${pr_desc}")" \
+                    --arg head "${branch_name}" \
+                    '{
+                        "base": "master",
+                        "title": $title,
+                        "body": $body,
+                        "head": $head,
+                        "maintainer_can_modify": true
+                    }')
+
+                echo "Creating pull request: POST /repos/${GH_OWNER}/${GH_REPO}/pulls"
+                # See also: https://developer.github.com/v3/
+                curl --silent --fail \
+                    --header "Accept: application/vnd.github.v3+json" \
+                    --header "Authorization: token ${GH_ACCESS_TOKEN}" \
+                    --request POST \
+                    --url "https://api.github.com/repos/${GH_OWNER}/${GH_REPO}/pulls" \
+                    --data-raw "${pr_data}"
+                exit 0

--- a/ci/consul-bump/repipe.sh
+++ b/ci/consul-bump/repipe.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+pushd "${SCRIPT_DIR}" > /dev/null
+
+(
+    set -x
+    fly -t "gk" \
+        set-pipeline -p "consul-bump" \
+        -c "consul-bump-pipeline.yml" \
+        -l "../config.yml" -l "../secrets.yml"
+)
+
+popd > /dev/null

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,5 +1,7 @@
 ### Features
 
+- Bump Consul to the latest version [1.6.2](https://github.com/hashicorp/consul/blob/master/CHANGELOG.md#162-november-13-2019)
+
 - Automate version bumps with a dedicated Concourse pipeline
 
 

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,13 @@
+### Features
+
+- Automate version bumps with a dedicated Concourse pipeline
+
+
+### Caveats
+
+- Poor suport for configuring local services to check. We setimate that in a
+  BOSH context, you should nowadays use the mature BOSH DNS features for
+  this.
+
+- Scaling-in from 3 nodes down to 1 node implies a short downtime (10-20
+  seconds) when BOSH re-configues the only remaining node.

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -14,12 +14,12 @@ credhub set -n "/concourse/${team}/git-commit-name"     -t value -v "$(bosh int 
 credhub set -n "/concourse/${team}/aws-access-key"      -t value -v "$(bosh int config/private.yml --path /blobstore/options/access_key_id)"
 credhub set -n "/concourse/${team}/aws-secret-key"      -t value -v "$(bosh int config/private.yml --path /blobstore/options/secret_access_key)"
 
-credhub set -n "/concourse/${team}/slack-username" -t value -v "gk-concourse-ninja"
-credhub set -n "/concourse/${team}/slack-icon-url" -t value -v "https://cl.ly/2F421Y300u07/concourse-logo-blue-transparent.png"
-credhub set -n "/concourse/${team}/slack-webhook"  -t value -v "$(bosh int ci/pipeline/secrets.yml --path /slack_webhook)"
+credhub set -n "/concourse/${team}/slack-username"            -t value -v "gk-concourse-ninja"
+credhub set -n "/concourse/${team}/slack-icon-url"            -t value -v "https://cl.ly/2F421Y300u07/concourse-logo-blue-transparent.png"
+credhub set -n "/concourse/${team}/${pipeline}/slack-webhook" -t value -v "$(bosh int ci/secrets.yml --path /slack_webhook)"
 
-credhub set -n "/concourse/${team}/github-access-token" -t value -v "$(bosh int ci/secrets.yml     --path /github_access_token)"
-credhub set -n "/concourse/${team}/github-private-key"  -t value -v "$(bosh int ci/secrets.yml     --path /github_private_key)"
+credhub set -n "/concourse/${team}/github-access-token" -t value -v "$(bosh int ci/secrets.yml --path /github_access_token)"
+credhub set -n "/concourse/${team}/github-private-key"  -t value -v "$(bosh int ci/secrets.yml --path /github_private_key)"
 
 credhub set -n "/concourse/${team}/bosh-lite-environment"   -t value -v "$(bosh int ci/secrets.yml --path /bosh-lite-environment)"
 credhub set -n "/concourse/${team}/bosh-lite-ca-cert"       -t value -v "$(bosh int ci/secrets.yml --path /bosh-lite-ca-cert)"

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.6.1_linux_amd64.zip:
-  size: 39965581
-  object_id: 15da1b6b-d463-4b64-65ac-658de9d4bafd
-  sha: sha256:a8568ca7b6797030b2c32615b4786d4cc75ce7aee2ed9025996fe92b07b31f7e
+consul/consul_1.6.2_linux_amd64.zip:
+  size: 40138455
+  sha: sha256:78d127e5b8edd310c3f9f89487fb833a5c7bcb4e09cb731a4d39100fc53b38be

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.6.2_linux_amd64.zip:
   size: 40138455
+  object_id: 59774e63-7b3a-43d3-4c06-4301d8cee964
   sha: sha256:78d127e5b8edd310c3f9f89487fb833a5c7bcb4e09cb731a4d39100fc53b38be

--- a/deploy/gk-consul.yml
+++ b/deploy/gk-consul.yml
@@ -61,6 +61,7 @@ variables:
     options:
       is_ca: true
       common_name: Consul CA
+    update_mode: converge
   - name: consul_agent_tls
     type: certificate
     update_mode: converge
@@ -74,6 +75,7 @@ variables:
         - "server.dc1.consul"
     consumes:
       alternative_name: { from: consul-server-address }
+    update_mode: converge
   - name: consul_ui_tls
     type: certificate
     update_mode: converge
@@ -87,6 +89,7 @@ variables:
         - "server.dc1.consul"
     consumes:
       alternative_name: { from: consul-ui-address }
+    update_mode: converge
 
 features:
   use_dns_addresses: true

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 function _config() {
-    readonly CONSUL_VERSION=1.6.1
+    readonly CONSUL_VERSION=1.6.2
 }
 
 function main() {

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,8 +3,8 @@
 set -ueo pipefail
 
 function configure() {
-    CONSUL_VERSION=1.6.1
-    CONSUL_SHA256=a8568ca7b6797030b2c32615b4786d4cc75ce7aee2ed9025996fe92b07b31f7e
+    CONSUL_VERSION=1.6.2
+    CONSUL_SHA256=78d127e5b8edd310c3f9f89487fb833a5c7bcb4e09cb731a4d39100fc53b38be
 }
 
 function main() {


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.6.2 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best