### PR TITLE
Bump Consul to version 1.7.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.7.2_linux_amd64.zip:
   size: 39650427
+  object_id: ba126115-985c-4e20-66ab-314fd24dc2c3
   sha: sha256:5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a756773e698

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.7.1_linux_amd64.zip:
-  size: 39641735
-  object_id: 102c27a2-4da7-4e4b-6bbb-96755b555b10
-  sha: sha256:09f3583c6cd7b1f748c0c012ce9b3d96de95a6c0d2334327b74f7d72b1fa5054
+consul/consul_1.7.2_linux_amd64.zip:
+  size: 39650427
+  sha: sha256:5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a756773e698

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 function _config() {
-    readonly CONSUL_VERSION=1.7.1
+    readonly CONSUL_VERSION=1.7.2
 }
 
 function main() {

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,8 +3,8 @@
 set -ueo pipefail
 
 function configure() {
-    CONSUL_VERSION=1.7.1
-    CONSUL_SHA256=09f3583c6cd7b1f748c0c012ce9b3d96de95a6c0d2334327b74f7d72b1fa5054
+    CONSUL_VERSION=1.7.2
+    CONSUL_SHA256=5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a756773e698
 }
 
 function main() {


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.7.2 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best