### PR TITLE
Bump Consul to version 1.8.4

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.7.2_linux_amd64.zip:
-  size: 39650427
-  object_id: ba126115-985c-4e20-66ab-314fd24dc2c3
-  sha: sha256:5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a756773e698
+consul/consul_1.8.4_linux_amd64.zip:
+  size: 42050230
+  sha: sha256:0d74525ee101254f1cca436356e8aee51247d460b56fc2b4f7faef8a6853141f

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.8.4_linux_amd64.zip:
   size: 42050230
+  object_id: d193d7f7-8e77-46ee-7db3-3cacf32bd78c
   sha: sha256:0d74525ee101254f1cca436356e8aee51247d460b56fc2b4f7faef8a6853141f

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 function _config() {
-    readonly CONSUL_VERSION=1.7.2
+    readonly CONSUL_VERSION=1.8.4
 }
 
 function main() {

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,8 +3,8 @@
 set -ueo pipefail
 
 function configure() {
-    CONSUL_VERSION=1.7.2
-    CONSUL_SHA256=5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a756773e698
+    CONSUL_VERSION=1.8.4
+    CONSUL_SHA256=0d74525ee101254f1cca436356e8aee51247d460b56fc2b4f7faef8a6853141f
 }
 
 function main() {


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.8.4 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best