### PR TITLE
Bump Consul to version 1.8.5

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.7.2_linux_amd64.zip:
-  size: 39650427
-  object_id: ba126115-985c-4e20-66ab-314fd24dc2c3
-  sha: sha256:5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a756773e698
+consul/consul_1.8.5_linux_amd64.zip:
+  size: 42189450
+  sha: sha256:94ab38e6221d3da393d0bbdf19cc524051253a75db078c31e249dad2c497ad46

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.8.5_linux_amd64.zip:
   size: 42189450
+  object_id: 0d0ce647-363f-4c96-79d5-26125285fe1b
   sha: sha256:94ab38e6221d3da393d0bbdf19cc524051253a75db078c31e249dad2c497ad46

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 function _config() {
-    readonly CONSUL_VERSION=1.7.2
+    readonly CONSUL_VERSION=1.8.5
 }
 
 function main() {

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,8 +3,8 @@
 set -ueo pipefail
 
 function configure() {
-    CONSUL_VERSION=1.7.2
-    CONSUL_SHA256=5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a756773e698
+    CONSUL_VERSION=1.8.5
+    CONSUL_SHA256=94ab38e6221d3da393d0bbdf19cc524051253a75db078c31e249dad2c497ad46
 }
 
 function main() {


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.8.5 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best