### PR TITLE
Bump Consul to version 1.9.0

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.8.5_linux_amd64.zip:
-  size: 42189450
-  object_id: 0d0ce647-363f-4c96-79d5-26125285fe1b
-  sha: sha256:94ab38e6221d3da393d0bbdf19cc524051253a75db078c31e249dad2c497ad46
+consul/consul_1.9.0_linux_amd64.zip:
+  size: 41245292
+  sha: sha256:409b964f9cec93ba4aa3f767fe3a57e14160d86ffab63c3697d188ba29d247ce

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.9.0_linux_amd64.zip:
   size: 41245292
+  object_id: b5f3b201-f90b-4be1-5ddd-20ed64bea16d
   sha: sha256:409b964f9cec93ba4aa3f767fe3a57e14160d86ffab63c3697d188ba29d247ce

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 function _config() {
-    readonly CONSUL_VERSION=1.8.5
+    readonly CONSUL_VERSION=1.9.0
 }
 
 function main() {

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,8 +3,8 @@
 set -ueo pipefail
 
 function configure() {
-    CONSUL_VERSION=1.8.5
-    CONSUL_SHA256=94ab38e6221d3da393d0bbdf19cc524051253a75db078c31e249dad2c497ad46
+    CONSUL_VERSION=1.9.0
+    CONSUL_SHA256=409b964f9cec93ba4aa3f767fe3a57e14160d86ffab63c3697d188ba29d247ce
 }
 
 function main() {


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.9.0 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Don't hesitate to have a look at the release notes: https://github.com/hashicorp/consul/blob/master/CHANGELOG.md
When it's okay to you, let's give it a shot, shall we?

Best