### PR TITLE
Bump Consul to version 1.9.3

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.9.3_linux_amd64.zip:
   size: 41321651
+  object_id: 068cd585-e475-4ae7-6fe0-c1a2aa928f40
   sha: sha256:2ec9203bf370ae332f6584f4decc2f25097ec9ef63852cd4ef58fdd27a313577

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.9.1_linux_amd64.zip:
-  size: 41289328
-  object_id: 7c33fc33-4f61-460f-700c-e0cecc40ff36
-  sha: sha256:9ba45ec6eb3e762444f077ae06e407ca5161d46785d725d7b5ea0c4d5cd5a99b
+consul/consul_1.9.3_linux_amd64.zip:
+  size: 41321651
+  sha: sha256:2ec9203bf370ae332f6584f4decc2f25097ec9ef63852cd4ef58fdd27a313577

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 function _config() {
-    readonly CONSUL_VERSION=1.9.1
+    readonly CONSUL_VERSION=1.9.3
 }
 
 function main() {

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,8 +3,8 @@
 set -ueo pipefail
 
 function configure() {
-    CONSUL_VERSION=1.9.1
-    CONSUL_SHA256=9ba45ec6eb3e762444f077ae06e407ca5161d46785d725d7b5ea0c4d5cd5a99b
+    CONSUL_VERSION=1.9.3
+    CONSUL_SHA256=2ec9203bf370ae332f6584f4decc2f25097ec9ef63852cd4ef58fdd27a313577
 }
 
 function main() {


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.9.3 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Don't hesitate to have a look at the release notes: https://github.com/hashicorp/consul/blob/master/CHANGELOG.md
When it's okay to you, let's give it a shot, shall we?

Best