### PR TITLE
Bump Consul to version 1.9.5

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -2,6 +2,8 @@
 
 - Switch to using Bionic stemcells
 
+- Bump Consul to the latest version [1.9.5](https://github.com/hashicorp/consul/blob/master/CHANGELOG.md#195-april-15-2021)
+
 
 ### Caveats
 

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.9.1_linux_amd64.zip:
-  size: 41289328
-  object_id: 7c33fc33-4f61-460f-700c-e0cecc40ff36
-  sha: sha256:9ba45ec6eb3e762444f077ae06e407ca5161d46785d725d7b5ea0c4d5cd5a99b
+consul/consul_1.9.5_linux_amd64.zip:
+  size: 41401971
+  sha: sha256:76e46d6711c92ffe573710345dc8c996605822eb6dbb371f895f011cda260035

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.9.5_linux_amd64.zip:
   size: 41401971
+  object_id: 105aada9-9dda-4790-6759-e30a1ad7961f
   sha: sha256:76e46d6711c92ffe573710345dc8c996605822eb6dbb371f895f011cda260035

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 function _config() {
-    readonly CONSUL_VERSION=1.9.1
+    readonly CONSUL_VERSION=1.9.5
 }
 
 function main() {

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,8 +3,8 @@
 set -ueo pipefail
 
 function configure() {
-    CONSUL_VERSION=1.9.1
-    CONSUL_SHA256=9ba45ec6eb3e762444f077ae06e407ca5161d46785d725d7b5ea0c4d5cd5a99b
+    CONSUL_VERSION=1.9.5
+    CONSUL_SHA256=76e46d6711c92ffe573710345dc8c996605822eb6dbb371f895f011cda260035
 }
 
 function main() {


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.9.5 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Don't hesitate to have a look at the release notes: https://github.com/hashicorp/consul/blob/master/CHANGELOG.md
When it's okay to you, let's give it a shot, shall we?

Best