### PR TITLE
Bump Consul to version 1.10.4

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.10.4_linux_amd64.zip:
   size: 38165215
+  object_id: 2447b17a-cfce-434f-4b44-0504bf51cfda
   sha: sha256:2be6414cdce1540c022acda76da55ef6bbd51c537dc2e3d4020652e72daec62d

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.9.5_linux_amd64.zip:
-  size: 41401971
-  object_id: 105aada9-9dda-4790-6759-e30a1ad7961f
-  sha: sha256:76e46d6711c92ffe573710345dc8c996605822eb6dbb371f895f011cda260035
+consul/consul_1.10.4_linux_amd64.zip:
+  size: 38165215
+  sha: sha256:2be6414cdce1540c022acda76da55ef6bbd51c537dc2e3d4020652e72daec62d

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 function _config() {
-    readonly CONSUL_VERSION=1.9.5
+    readonly CONSUL_VERSION=1.10.4
 }
 
 function main() {

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,8 +3,8 @@
 set -ueo pipefail
 
 function configure() {
-    CONSUL_VERSION=1.9.5
-    CONSUL_SHA256=76e46d6711c92ffe573710345dc8c996605822eb6dbb371f895f011cda260035
+    CONSUL_VERSION=1.10.4
+    CONSUL_SHA256=2be6414cdce1540c022acda76da55ef6bbd51c537dc2e3d4020652e72daec62d
 }
 
 function main() {


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.10.4 is out, so I suggest we update this BOSH Release with the latest artifact available.

Here in this PR, I've pulled that new artifact in. I've already uploaded the blob to the release blobstore, and here is the result.

Don't hesitate to have a look at the release notes: https://github.com/hashicorp/consul/blob/master/CHANGELOG.md
When it's okay to you, let's give it a shot, shall we?

Best