### PR TITLE
Bump Consul to version 1.17.0

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.9.5_linux_amd64.zip:
-  size: 41401971
-  object_id: 105aada9-9dda-4790-6759-e30a1ad7961f
-  sha: sha256:76e46d6711c92ffe573710345dc8c996605822eb6dbb371f895f011cda260035
+consul/consul_1.17.0_linux_amd64.zip:
+  size: 64134521
+  sha: sha256:4fbb6c3a05ddfc72d314149fe9765a1be89c33857b003a1d861469f2fe97e23e

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.17.0_linux_amd64.zip:
   size: 64134521
+  object_id: 0953cd0e-f088-480f-4311-55dfd651ed3e
   sha: sha256:4fbb6c3a05ddfc72d314149fe9765a1be89c33857b003a1d861469f2fe97e23e

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 function _config() {
-    readonly CONSUL_VERSION=1.9.5
+    readonly CONSUL_VERSION=1.17.0
 }
 
 function main() {

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,8 +3,8 @@
 set -ueo pipefail
 
 function configure() {
-    CONSUL_VERSION=1.9.5
-    CONSUL_SHA256=76e46d6711c92ffe573710345dc8c996605822eb6dbb371f895f011cda260035
+    CONSUL_VERSION=1.17.0
+    CONSUL_SHA256=4fbb6c3a05ddfc72d314149fe9765a1be89c33857b003a1d861469f2fe97e23e
 }
 
 function main() {


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.17.0 is out, so I suggest we update this BOSH Release with the latest artifact available.

Here in this PR, I've pulled that new artifact in. I've already uploaded the blob to the release blobstore, and here is the result.

Don't hesitate to have a look at the release notes: https://github.com/hashicorp/consul/blob/master/CHANGELOG.md
When it's okay to you, let's give it a shot, shall we?

Best