### PR TITLE
Bump Consul to version 1.18.1

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,8 +1,8 @@
 ### Features
 
-- Bump Consul to the latest version [1.10.4](https://github.com/hashicorp/consul/blob/main/CHANGELOG.md#1104-november-11-2021)
+- Bump Consul to the latest version [1.18.1](https://github.com/hashicorp/consul/blob/main/CHANGELOG.md#1181-march-26-2024)
 
-- Bump BPM to v1.1.15 in the standard deployment manifest.
+- Bump BPM to v1.2.19 in the standard deployment manifest.
 
 
 ### Caveats

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.9.5_linux_amd64.zip:
-  size: 41401971
-  object_id: 105aada9-9dda-4790-6759-e30a1ad7961f
-  sha: sha256:76e46d6711c92ffe573710345dc8c996605822eb6dbb371f895f011cda260035
+consul/consul_1.18.1_linux_amd64.zip:
+  size: 66798452
+  sha: sha256:5faa9cc3f2832e3ae454a3ec2dbc6799179d14e1e09463f220bb906c590f4b05

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.18.1_linux_amd64.zip:
   size: 66798452
+  object_id: 10f91060-bea4-45a3-79f5-71834da37728
   sha: sha256:5faa9cc3f2832e3ae454a3ec2dbc6799179d14e1e09463f220bb906c590f4b05

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 function _config() {
-    readonly CONSUL_VERSION=1.9.5
+    readonly CONSUL_VERSION=1.18.1
 }
 
 function main() {

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,8 +3,8 @@
 set -ueo pipefail
 
 function configure() {
-    CONSUL_VERSION=1.9.5
-    CONSUL_SHA256=76e46d6711c92ffe573710345dc8c996605822eb6dbb371f895f011cda260035
+    CONSUL_VERSION=1.18.1
+    CONSUL_SHA256=5faa9cc3f2832e3ae454a3ec2dbc6799179d14e1e09463f220bb906c590f4b05
 }
 
 function main() {


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.18.1 is out, so I suggest we update this BOSH Release with the latest artifact available.

Here in this PR, I've pulled that new artifact in. I've already uploaded the blob to the release blobstore, and here is the result.

Don't hesitate to have a look at the release notes: https://github.com/hashicorp/consul/blob/master/CHANGELOG.md
When it's okay to you, let's give it a shot, shall we?

Best