### PR TITLE
Bump Consul to version 1.19.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.18.1_linux_amd64.zip:
-  size: 66798452
-  object_id: 10f91060-bea4-45a3-79f5-71834da37728
-  sha: sha256:5faa9cc3f2832e3ae454a3ec2dbc6799179d14e1e09463f220bb906c590f4b05
+consul/consul_1.19.1_linux_amd64.zip:
+  size: 68872345
+  sha: sha256:aa48085aaa6f4130d0f1ee98c416dcd51b1b0f980d34f5b91834fd5b3387891c

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.19.1_linux_amd64.zip:
   size: 68872345
+  object_id: 791847d4-3284-4e23-6b45-e62ad295ab7b
   sha: sha256:aa48085aaa6f4130d0f1ee98c416dcd51b1b0f980d34f5b91834fd5b3387891c

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 function _config() {
-    readonly CONSUL_VERSION=1.18.1
+    readonly CONSUL_VERSION=1.19.1
 }
 
 function main() {

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,8 +3,8 @@
 set -ueo pipefail
 
 function configure() {
-    CONSUL_VERSION=1.18.1
-    CONSUL_SHA256=5faa9cc3f2832e3ae454a3ec2dbc6799179d14e1e09463f220bb906c590f4b05
+    CONSUL_VERSION=1.19.1
+    CONSUL_SHA256=aa48085aaa6f4130d0f1ee98c416dcd51b1b0f980d34f5b91834fd5b3387891c
 }
 
 function main() {


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.19.1 is out, so I suggest we update this BOSH Release with the latest artifact available.

Here in this PR, I've pulled that new artifact in. I've already uploaded the blob to the release blobstore, and here is the result.

Don't hesitate to have a look at the release notes: https://github.com/hashicorp/consul/blob/master/CHANGELOG.md
When it's okay to you, let's give it a shot, shall we?

Best