### PR TITLE
Bump Consul to version 1.20.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 consul/consul_1.20.1_linux_amd64.zip:
   size: 67017185
+  object_id: 04f3ac12-df41-4ffe-47a3-c6f13f3b2d73
   sha: sha256:d38e7571177909d437a9cbcc62fb65083bc567266b74a62d02c6abe783951648

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-consul/consul_1.18.1_linux_amd64.zip:
-  size: 66798452
-  object_id: 10f91060-bea4-45a3-79f5-71834da37728
-  sha: sha256:5faa9cc3f2832e3ae454a3ec2dbc6799179d14e1e09463f220bb906c590f4b05
+consul/consul_1.20.1_linux_amd64.zip:
+  size: 67017185
+  sha: sha256:d38e7571177909d437a9cbcc62fb65083bc567266b74a62d02c6abe783951648

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 function _config() {
-    readonly CONSUL_VERSION=1.18.1
+    readonly CONSUL_VERSION=1.20.1
 }
 
 function main() {

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,8 +3,8 @@
 set -ueo pipefail
 
 function configure() {
-    CONSUL_VERSION=1.18.1
-    CONSUL_SHA256=5faa9cc3f2832e3ae454a3ec2dbc6799179d14e1e09463f220bb906c590f4b05
+    CONSUL_VERSION=1.20.1
+    CONSUL_SHA256=d38e7571177909d437a9cbcc62fb65083bc567266b74a62d02c6abe783951648
 }
 
 function main() {


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.20.1 is out, so I suggest we update this BOSH Release with the latest artifact available.

Here in this PR, I've pulled that new artifact in. I've already uploaded the blob to the release blobstore, and here is the result.

Don't hesitate to have a look at the release notes: https://github.com/hashicorp/consul/blob/master/CHANGELOG.md
When it's okay to you, let's give it a shot, shall we?

Best